### PR TITLE
Update release to 22.11.00

### DIFF
--- a/Formula/astartectl.rb
+++ b/Formula/astartectl.rb
@@ -1,8 +1,8 @@
 class Astartectl < Formula
   desc "Astarte command-line client utility"
   homepage "https://astarte.cloud"
-  url "https://github.com/astarte-platform/astartectl/archive/v1.0.0.tar.gz"
-  sha256 "696782652e4bcefe61fc2007ce62d7f4f86725ec0e51a008111ec32757d39740"
+  url "https://github.com/astarte-platform/astartectl/archive/v22.11.00.tar.gz"
+  sha256 "4e5eaf5c4215424d3bf420f601d426cdb0c2b069ae46f248aefe56dfa9440640"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Update formula to install the latest astartectl release (v22.11.00).